### PR TITLE
Fixed Community Visibility in Database

### DIFF
--- a/src/main/java/iluvus/backend/api/service/CommunityService.java
+++ b/src/main/java/iluvus/backend/api/service/CommunityService.java
@@ -26,7 +26,7 @@ public class CommunityService {
             communityDto.setName(data.get("name"));
             communityDto.setDescription(data.get("description"));
             communityDto.setRule(data.get("rules"));
-            communityDto.setPublic(Boolean.valueOf(data.get("visibility")));
+            communityDto.setPublic(data.get("visibility").equals("Public"));
 
             User owner = userRepository.findUserbyUsername(data.get("ownerId"));
             communityDto.setOwner(owner);


### PR DESCRIPTION
Simple bug fix in the Database. Before, the community visibility was always set to false regardless of what user picked in the UI. If user picked "Public", then frontend passed "Public" as the visibility and backend checked if "Public" equals True. Therefore, it was always false. Therefore Database had all newly created community visibility to private. Fixed this issue so now Database stores the correct visibility. 